### PR TITLE
Add the flag for internal ELB

### DIFF
--- a/docker/helm/templates/service.yaml
+++ b/docker/helm/templates/service.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.service.hostname }}
+    {{- if .Values.service.internal }}
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    {{- end }}
   labels:
     {{- include "s3zipper.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Add the flag so we can make the ELB internal.
Part of the work to move away from public ELBs where possible.

[task](https://digitalcrew.teamwork.com/app/tasks/23082907)
